### PR TITLE
Add enumerate to builtins

### DIFF
--- a/homeassistant/components/python_script/__init__.py
+++ b/homeassistant/components/python_script/__init__.py
@@ -184,6 +184,7 @@ def execute(hass, filename, source, data=None):
     builtins["sorted"] = sorted
     builtins["time"] = TimeWrapper()
     builtins["dt_util"] = dt_util
+    builtins["enumerate"] = enumerate
     logger = logging.getLogger(f"{__name__}.{filename}")
     restricted_globals = {
         "__builtins__": builtins,

--- a/tests/components/python_script/test_init.py
+++ b/tests/components/python_script/test_init.py
@@ -179,6 +179,20 @@ for i in [1, 2]:
     assert hass.states.is_state("hello.2", "world")
 
 
+async def test_using_enumerate(hass):
+    """Test that enumerate is accepted and executed."""
+    source = """
+for index, value in enumerate(["earth", "mars"]):
+    hass.states.set('hello.{}'.format(index), value)
+    """
+
+    hass.async_add_job(execute, hass, "test.py", source, {})
+    await hass.async_block_till_done()
+
+    assert hass.states.is_state("hello.0", "earth")
+    assert hass.states.is_state("hello.1", "mars")
+
+
 async def test_unpacking_sequence(hass, caplog):
     """Test compile error logs error."""
     caplog.set_level(logging.ERROR)


### PR DESCRIPTION

## Proposed change
If we check RestrictedPython it says enumerate is already available via Zope Guards and checking Zope it already has enumerate added to the safe_builtins. So it makes sense to have it available in HA python_scripts too. It is an essential pythonic tool for handling loops and indices.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #54241

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
